### PR TITLE
Registrable onlooks

### DIFF
--- a/data-vaigu/scripts/quests/_vaigu/Desert_quest_two/fast_moa_lever.lua
+++ b/data-vaigu/scripts/quests/_vaigu/Desert_quest_two/fast_moa_lever.lua
@@ -1,8 +1,11 @@
+-- require("lldebuggr").start()
+
 local stonePos = DESERT_QUEST_TWO_ANCHOR:Moved(41, -6, 0)
 local moaPos = DESERT_QUEST_TWO_ANCHOR:Moved(45, -17, 0)
 
 local lever = Action()
 function lever.onUse(creature, _, _, _, _, _)
+	print("MOA LEVER USE")
 	local player = creature:getPlayer()
 	if not player then
 		return false
@@ -28,3 +31,12 @@ end
 
 lever:aid(Storage.DesertQuestTwo.Puzzles.FastMoaLever)
 lever:register()
+
+local item2 = Look()
+function item2.onLook(a, b, c, d, e, f)
+	print("MOA LEVER LOOK")
+	print(a, b, c, d, e, f)
+	return true
+end
+item2:aid(Storage.DesertQuestTwo.Puzzles.FastMoaLever)
+item2:register()

--- a/data/libs/functions/revscriptsys.lua
+++ b/data/libs/functions/revscriptsys.lua
@@ -90,6 +90,17 @@ do
 	rawgetmetatable("Action").__newindex = ActionNewIndex
 end
 
+do
+	local function LookNewIndex(self, key, value)
+		if key == "onLook" then
+			self:onLook(value)
+			return
+		end
+		rawset(self, key, value)
+	end
+	rawgetmetatable("Look").__newindex = LookNewIndex
+end
+
 -- TalkAction revscriptsys
 do
 	local function TalkActionNewIndex(self, key, value)

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -12,6 +12,7 @@
 #include "game/game.hpp"
 
 #include "lua/creature/actions.hpp"
+#include "lua/creature/looks.hpp"
 #include "items/bed.hpp"
 #include "creatures/creature.hpp"
 #include "database/databasetasks.hpp"
@@ -5310,6 +5311,7 @@ void Game::playerLookAt(uint32_t playerId, uint16_t itemId, const Position &pos,
 		player->sendCancelMessage(RETURNVALUE_NOTPOSSIBLE);
 		return;
 	}
+	std::shared_ptr<Item> item = thing->getItem();
 
 	Position thingPos = thing->getPosition();
 	if (!player->canSee(thingPos)) {
@@ -5330,6 +5332,10 @@ void Game::playerLookAt(uint32_t playerId, uint16_t itemId, const Position &pos,
 	}
 
 	// Parse onLook from event player
+	// ToDo: TEST
+	if (g_looks().lookItemEx(player, player->getPosition(), pos, stackPos, item)) {
+		return;
+	}
 	g_events().eventPlayerOnLook(player, pos, thing, stackPos, lookDistance);
 	g_callbacks().executeCallback(EventCallback_t::playerOnLook, &EventCallback::playerOnLook, player, pos, thing, stackPos, lookDistance);
 }

--- a/src/lua/creature/looks.cpp
+++ b/src/lua/creature/looks.cpp
@@ -1,0 +1,348 @@
+/**
+ * Canary - A free and open-source MMORPG server emulator
+ * Copyright (©) 2019-2024 OpenTibiaBR <opentibiabr@outlook.com>
+ * Repository: https://github.com/opentibiabr/canary
+ * License: https://github.com/opentibiabr/canary/blob/main/LICENSE
+ * Contributors: https://github.com/opentibiabr/canary/graphs/contributors
+ * Website: https://docs.opentibiabr.com/
+ */
+
+#include "pch.hpp"
+
+#include "lua/creature/Looks.hpp"
+#include "items/bed.hpp"
+#include "items/containers/container.hpp"
+#include "game/game.hpp"
+#include "creatures/combat/spells.hpp"
+#include "items/containers/rewards/rewardchest.hpp"
+#include "enums/account_group_type.hpp"
+
+Looks::Looks() = default;
+Looks::~Looks() = default;
+
+void Looks::clear() {
+	useItemMap.clear();
+	uniqueItemMap.clear();
+	actionItemMap.clear();
+	actionPositionMap.clear();
+}
+
+bool Looks::registerLuaItemEvent(const std::shared_ptr<Look> look) {
+	auto itemIdVector = look->getItemIdsVector();
+	if (itemIdVector.empty()) {
+		return false;
+	}
+
+	std::vector<uint16_t> tmpVector;
+	tmpVector.reserve(itemIdVector.size());
+
+	for (const auto &itemId : itemIdVector) {
+		// Check if the item is already registered and prevent it from being registered again
+		if (hasItemId(itemId)) {
+			g_logger().warn(
+				"[{}] - Duplicate "
+				"registered item with id: {} in range from id: {}, to id: {}, for script: {}",
+				__FUNCTION__,
+				itemId,
+				itemIdVector.at(0),
+				itemIdVector.at(itemIdVector.size() - 1),
+				look->getScriptInterface()->getLoadingScriptName()
+			);
+			continue;
+		}
+
+		// Register item in the look item map
+		setItemId(itemId, look);
+		tmpVector.emplace_back(itemId);
+	}
+
+	itemIdVector = std::move(tmpVector);
+	return !itemIdVector.empty();
+}
+
+bool Looks::registerLuaUniqueEvent(const std::shared_ptr<Look> look) {
+	auto uniqueIdVector = look->getUniqueIdsVector();
+	if (uniqueIdVector.empty()) {
+		return false;
+	}
+
+	std::vector<uint16_t> tmpVector;
+	tmpVector.reserve(uniqueIdVector.size());
+
+	for (const auto &uniqueId : uniqueIdVector) {
+		// Check if the unique is already registered and prevent it from being registered again
+		if (!hasUniqueId(uniqueId)) {
+			// Register unique id the unique item map
+			setUniqueId(uniqueId, look);
+			tmpVector.emplace_back(uniqueId);
+		} else {
+			g_logger().warn(
+				"[{}] duplicate registered item with uid: {} in range from uid: {}, to uid: {}, for script: {}",
+				__FUNCTION__,
+				uniqueId,
+				uniqueIdVector.at(0),
+				uniqueIdVector.at(uniqueIdVector.size() - 1),
+				look->getScriptInterface()->getLoadingScriptName()
+			);
+		}
+	}
+
+	uniqueIdVector = std::move(tmpVector);
+	return !uniqueIdVector.empty();
+}
+
+bool Looks::registerLuaActionEvent(const std::shared_ptr<Look> look) {
+	auto actionIdVector = look->getActionIdsVector();
+	if (actionIdVector.empty()) {
+		return false;
+	}
+
+	std::vector<uint16_t> tmpVector;
+	tmpVector.reserve(actionIdVector.size());
+
+	for (const auto &actionId : actionIdVector) {
+		// Check if the unique is already registered and prevent it from being registered again
+		if (!hasActionId(actionId)) {
+			// Register look in the look item map
+			setActionId(actionId, look);
+			tmpVector.emplace_back(actionId);
+		} else {
+			g_logger().warn(
+				"[{}] duplicate registered item with aid: {} in range from aid: {}, to aid: {}, for script: {}",
+				__FUNCTION__,
+				actionId,
+				actionIdVector.at(0),
+				actionIdVector.at(actionIdVector.size() - 1),
+				look->getScriptInterface()->getLoadingScriptName()
+			);
+		}
+	}
+
+	actionIdVector = std::move(tmpVector);
+	return !actionIdVector.empty();
+}
+
+bool Looks::registerLuaPositionEvent(const std::shared_ptr<Look> look) {
+	auto positionVector = look->getPositionsVector();
+	if (positionVector.empty()) {
+		return false;
+	}
+
+	std::vector<Position> tmpVector;
+	tmpVector.reserve(positionVector.size());
+
+	for (const auto &position : positionVector) {
+		// Check if the position is already registered and prevent it from being registered again
+		if (!hasPosition(position)) {
+			// Register position in the look position map
+			setPosition(position, look);
+			tmpVector.emplace_back(position);
+		} else {
+			g_logger().warn(
+				"[{}] duplicate registered script with range position: {}, for script: {}",
+				__FUNCTION__,
+				position.toString(),
+				look->getScriptInterface()->getLoadingScriptName()
+			);
+		}
+	}
+
+	positionVector = std::move(tmpVector);
+	return !positionVector.empty();
+}
+
+bool Looks::registerLuaEvent(const std::shared_ptr<Look> look) {
+	// Call all register lua events
+	if (registerLuaItemEvent(look) || registerLuaUniqueEvent(look) || registerLuaActionEvent(look) || registerLuaPositionEvent(look)) {
+		return true;
+	} else {
+		g_logger().warn(
+			"[{}] missing id/aid/uid/position for one script event, for script: {}",
+			__FUNCTION__,
+			look->getScriptInterface()->getLoadingScriptName()
+		);
+		return false;
+	}
+	g_logger().debug("[{}] missing or incorrect script: {}", __FUNCTION__, look->getScriptInterface()->getLoadingScriptName());
+	return false;
+}
+
+ReturnValue Looks::canLook(std::shared_ptr<Player> player, const Position &pos) {
+	if (pos.x != 0xFFFF) {
+		const Position &playerPos = player->getPosition();
+		if (playerPos.z != pos.z) {
+			return playerPos.z > pos.z ? RETURNVALUE_FIRSTGOUPSTAIRS : RETURNVALUE_FIRSTGODOWNSTAIRS;
+		}
+
+		if (!Position::areInRange<1, 1>(playerPos, pos)) {
+			return RETURNVALUE_TOOFARAWAY;
+		}
+	}
+	return RETURNVALUE_NOERROR;
+}
+
+ReturnValue Looks::canLook(std::shared_ptr<Player> player, const Position &pos, std::shared_ptr<Item> item) {
+	const std::shared_ptr<Look> look = getLook(item);
+	if (look != nullptr) {
+		return look->canExecuteLook(player, pos);
+	}
+	return RETURNVALUE_NOERROR;
+}
+
+std::shared_ptr<Look> Looks::getLook(std::shared_ptr<Item> item) {
+	if (item->hasAttribute(ItemAttribute_t::UNIQUEID)) {
+		auto it = uniqueItemMap.find(item->getAttribute<uint16_t>(ItemAttribute_t::UNIQUEID));
+		if (it != uniqueItemMap.end()) {
+			return it->second;
+		}
+	}
+
+	if (item->hasAttribute(ItemAttribute_t::ACTIONID)) {
+		auto it = actionItemMap.find(item->getAttribute<uint16_t>(ItemAttribute_t::ACTIONID));
+		if (it != actionItemMap.end()) {
+			return it->second;
+		}
+	}
+
+	auto it = useItemMap.find(item->getID());
+	if (it != useItemMap.end()) {
+		return it->second;
+	}
+
+	if (auto iteratePositions = actionPositionMap.find(item->getPosition());
+	    iteratePositions != actionPositionMap.end()) {
+		if (std::shared_ptr<Tile> tile = item->getTile();
+		    tile) {
+			if (std::shared_ptr<Player> player = item->getHoldingPlayer();
+			    player && item->getTopParent() == player) {
+				g_logger().debug("[Looks::getAction] - The position only is valid for use item in the map, player name {}", player->getName());
+				return nullptr;
+			}
+
+			return iteratePositions->second;
+		}
+	}
+
+	return nullptr;
+}
+
+/*
+ReturnValue Looks::internalLookItem(std::shared_ptr<Player> player, const Position &fromPos, uint8_t stackPos, std::shared_ptr<Item> item, const Position &toPos) {
+    if (std::shared_ptr<Door> door = item->getDoor()) {
+        if (!door->canUse(player)) {
+            return RETURNVALUE_CANNOTUSETHISOBJECT;
+        }
+    }
+
+    auto itemId = item->getID();
+    const ItemType &itemType = Item::items[itemId];
+    auto transformTo = itemType.m_transformOnUse;
+    const std::shared_ptr<Look> look = getLook(item);
+    if (!look && transformTo > 0 && itemId != transformTo) {
+        if (g_game().transformItem(item, transformTo) == nullptr) {
+            g_logger().warn("[{}] item with id {} failed to transform to item {}", __FUNCTION__, itemId, transformTo);
+            return RETURNVALUE_CANNOTUSETHISOBJECT;
+        }
+
+        return RETURNVALUE_NOERROR;
+    } else if (transformTo > 0 && look) {
+        g_logger().warn("[{}] item with id {} already have look registered and cannot be use transformTo tag", __FUNCTION__, itemId);
+    }
+
+    if (look != nullptr) {
+        if (look->isLoadedCallback()) {
+            if (look->executeLook(player, item, fromPos, nullptr, fromPos)) {
+                return RETURNVALUE_NOERROR;
+            }
+            if (item->isRemoved()) {
+                return RETURNVALUE_CANNOTUSETHISOBJECT;
+            }
+        } else if (look->useFunction && look->useFunction(player, item, fromPos, nullptr, toPos)) {
+            return RETURNVALUE_NOERROR;
+        }
+    }
+
+    return RETURNVALUE_CANNOTUSETHISOBJECT;
+}
+*/
+
+bool Looks::lookItemEx(std::shared_ptr<Player> player, const Position &fromPos, const Position &toPos, uint8_t toStackPos, std::shared_ptr<Item> item, std::shared_ptr<Creature> creature /* = nullptr*/) {
+	if (item == nullptr) {
+		return false;
+	}
+	const ItemType &it = Item::items[item->getID()];
+
+	const std::shared_ptr<Look> look = getLook(item);
+	if (look == nullptr) {
+		return false;
+	}
+
+	if (look->useFunction) {
+		if (look->useFunction(player, item, fromPos, look->getTarget(player, creature, toPos, toStackPos), toPos)) {
+			return true;
+		}
+	}
+	if (look->isLoadedCallback()) {
+		if (look->executeLook(player, item, fromPos, creature, toPos)) {
+			return true;
+		}
+		if (item->isRemoved()) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+/*
+ ================
+ Look interface
+ ================
+*/
+
+// Look constructor
+Look::Look(LuaScriptInterface* interface) :
+	Script(interface) { }
+
+ReturnValue Look::canExecuteLook(std::shared_ptr<Player> player, const Position &toPos) {
+	if (!allowFarUse) {
+		return g_looks().canLook(player, toPos);
+	}
+	return RETURNVALUE_NOERROR;
+}
+
+std::shared_ptr<Thing> Look::getTarget(std::shared_ptr<Player> player, std::shared_ptr<Creature> targetCreature, const Position &toPosition, uint8_t toStackPos) const {
+	if (targetCreature != nullptr) {
+		return targetCreature;
+	}
+	return g_game().internalGetThing(player, toPosition, toStackPos, 0, STACKPOS_USETARGET);
+}
+
+
+bool Look::executeLook(std::shared_ptr<Player> player, std::shared_ptr<Item> item, const Position &fromPosition, std::shared_ptr<Thing> target, const Position &toPosition) {
+    // onUse(player, item, fromPosition, target, toPosition, isHotkey)
+    if (!getScriptInterface()->reserveScriptEnv()) {
+        g_logger().error("[Look::executeLook - Player {}, on item {}] "
+                         "Call stack overflow. Too many lua script calls being nested.",
+                         player->getName(), item->getName());
+        return false;
+    }
+
+    ScriptEnvironment* scriptEnvironment = getScriptInterface()->getScriptEnv();
+    scriptEnvironment->setScriptId(getScriptId(), getScriptInterface());
+
+    lua_State* L = getScriptInterface()->getLuaState();
+
+    getScriptInterface()->pushFunction(getScriptId());
+
+    LuaScriptInterface::pushUserdata<Player>(L, player);
+    LuaScriptInterface::setMetatable(L, -1, "Player");
+
+    LuaScriptInterface::pushThing(L, item);
+    LuaScriptInterface::pushPosition(L, fromPosition);
+
+    LuaScriptInterface::pushThing(L, target);
+    LuaScriptInterface::pushPosition(L, toPosition);
+
+    return getScriptInterface()->callFunction(5);
+}

--- a/src/lua/creature/looks.hpp
+++ b/src/lua/creature/looks.hpp
@@ -1,0 +1,213 @@
+/**
+ * Canary - A free and open-source MMORPG server emulator
+ * Copyright (©) 2019-2024 OpenTibiaBR <opentibiabr@outlook.com>
+ * Repository: https://github.com/opentibiabr/canary
+ * License: https://github.com/opentibiabr/canary/blob/main/LICENSE
+ * Contributors: https://github.com/opentibiabr/canary/graphs/contributors
+ * Website: https://docs.opentibiabr.com/
+ */
+
+#pragma once
+
+#include "lua/scripts/scripts.hpp"
+#include "declarations.hpp"
+#include "lua/scripts/luascript.hpp"
+
+class Look;
+class Position;
+
+class Look : public Script {
+public:
+	explicit Look(LuaScriptInterface* interface);
+
+	// Scripting
+	bool getCheckLineOfSight() const {
+		return checkLineOfSight;
+	}
+
+	void setCheckLineOfSight(bool state) {
+		checkLineOfSight = state;
+	}
+
+	bool getCheckFloor() const {
+		return checkFloor;
+	}
+
+	void setCheckFloor(bool state) {
+		checkFloor = state;
+	}
+
+	std::vector<uint16_t> getItemIdsVector() const {
+		return itemIds;
+	}
+
+	void setItemIdsVector(uint16_t id) {
+		itemIds.emplace_back(id);
+	}
+
+	std::vector<uint16_t> getUniqueIdsVector() const {
+		return uniqueIds;
+	}
+
+	void setUniqueIdsVector(uint16_t id) {
+		uniqueIds.emplace_back(id);
+	}
+
+	std::vector<uint16_t> getActionIdsVector() const {
+		return actionIds;
+	}
+
+	void setActionIdsVector(uint16_t id) {
+		actionIds.emplace_back(id);
+	}
+
+	std::vector<Position> getPositionsVector() const {
+		return positions;
+	}
+
+	void setPositionsVector(Position pos) {
+		positions.emplace_back(pos);
+	}
+
+	bool hasPosition(Position position) {
+		return std::ranges::find_if(positions.begin(), positions.end(), [position](Position storedPosition) {
+				   if (storedPosition == position) {
+					   return true;
+				   }
+				   return false;
+			   })
+			!= positions.end();
+	}
+
+	std::vector<Position> getPositions() const {
+		return positions;
+	}
+	void setPositions(Position pos) {
+		positions.emplace_back(pos);
+	}
+
+	std::shared_ptr<Thing> getTarget(std::shared_ptr<Player> player, std::shared_ptr<Creature> targetCreature, const Position &toPosition, uint8_t toStackPos) const;
+
+	virtual ReturnValue canExecuteLook(std::shared_ptr<Player> player, const Position &toPos);
+	bool executeLook(std::shared_ptr<Player> player, std::shared_ptr<Item> item, const Position &fromPosition, std::shared_ptr<Thing> target, const Position &toPosition);
+
+	virtual bool hasOwnErrorHandler() {
+		return false;
+	}
+
+private:
+	std::string getScriptTypeName() const override {
+		return "onLook";
+	}
+
+	std::function<bool(
+		std::shared_ptr<Player> player, std::shared_ptr<Item> item,
+		const Position &fromPosition, std::shared_ptr<Thing> target,
+		const Position &toPosition
+	)>
+		useFunction = nullptr;
+
+	// Atributes
+	bool allowFarUse = false;
+	bool checkFloor = true;
+	bool checkLineOfSight = true;
+
+	// IDs
+	std::vector<uint16_t> itemIds;
+	std::vector<uint16_t> uniqueIds;
+	std::vector<uint16_t> actionIds;
+	std::vector<Position> positions;
+
+	friend class Looks;
+};
+
+class Looks final : public Scripts {
+public:
+	Looks();
+	~Looks();
+
+	// non-copyable
+	Looks(const Looks &) = delete;
+	Looks &operator=(const Looks &) = delete;
+
+	static Looks &getInstance() {
+		return inject<Looks>();
+	}
+
+	bool lookItemEx(std::shared_ptr<Player> player, const Position &fromPos, const Position &toPos, uint8_t stackPos, std::shared_ptr<Item> item, std::shared_ptr<Creature> creature = nullptr);
+	std::shared_ptr<Look> getLook(std::shared_ptr<Item> item);
+
+	ReturnValue canLook(std::shared_ptr<Player> player, const Position &pos);
+	ReturnValue canLook(std::shared_ptr<Player> player, const Position &pos, std::shared_ptr<Item> item);
+
+	bool registerLuaItemEvent(const std::shared_ptr<Look> look);
+	bool registerLuaUniqueEvent(const std::shared_ptr<Look> look);
+	bool registerLuaActionEvent(const std::shared_ptr<Look> look);
+	bool registerLuaPositionEvent(const std::shared_ptr<Look> look);
+	bool registerLuaEvent(const std::shared_ptr<Look> look);
+	// Clear maps for reloading
+	void clear();
+
+private:
+	bool hasPosition(Position position) const {
+		if (auto it = actionPositionMap.find(position);
+		    it != actionPositionMap.end()) {
+			return true;
+		}
+		return false;
+	}
+
+	[[nodiscard]] std::map<Position, std::shared_ptr<Look>> getPositionsMap() const {
+		return actionPositionMap;
+	}
+
+	void setPosition(Position position, std::shared_ptr<Look> action) {
+		actionPositionMap.try_emplace(position, action);
+	}
+
+	bool hasItemId(uint16_t itemId) const {
+		if (auto it = useItemMap.find(itemId);
+		    it != useItemMap.end()) {
+			return true;
+		}
+		return false;
+	}
+
+	void setItemId(uint16_t itemId, const std::shared_ptr<Look> action) {
+		useItemMap.try_emplace(itemId, action);
+	}
+
+	bool hasUniqueId(uint16_t uniqueId) const {
+		if (auto it = uniqueItemMap.find(uniqueId);
+		    it != uniqueItemMap.end()) {
+			return true;
+		}
+		return false;
+	}
+
+	void setUniqueId(uint16_t uniqueId, const std::shared_ptr<Look> action) {
+		uniqueItemMap.try_emplace(uniqueId, action);
+	}
+
+	bool hasActionId(uint16_t actionId) const {
+		if (auto it = actionItemMap.find(actionId);
+		    it != actionItemMap.end()) {
+			return true;
+		}
+		return false;
+	}
+
+	void setActionId(uint16_t actionId, const std::shared_ptr<Look> action) {
+		actionItemMap.try_emplace(actionId, action);
+	}
+
+	// ReturnValue internalLookItem(std::shared_ptr<Player> player, const Position &fromPos, uint8_t stackPos, std::shared_ptr<Item> item, const Position &toPos);
+
+	using LookMap = std::map<uint16_t, std::shared_ptr<Look>>;
+	LookMap useItemMap;
+	LookMap uniqueItemMap;
+	LookMap actionItemMap;
+	std::map<Position, std::shared_ptr<Look>> actionPositionMap;
+};
+
+constexpr auto g_looks = Looks::getInstance;

--- a/src/lua/functions/events/events_functions.hpp
+++ b/src/lua/functions/events/events_functions.hpp
@@ -11,6 +11,7 @@
 
 #include "lua/scripts/luascript.hpp"
 #include "lua/functions/events/action_functions.hpp"
+#include "lua/functions/events/look_functions.hpp"
 #include "lua/functions/events/creature_event_functions.hpp"
 #include "lua/functions/events/events_scheduler_functions.hpp"
 #include "lua/functions/events/global_event_functions.hpp"
@@ -22,6 +23,7 @@ class EventFunctions final : LuaScriptInterface {
 public:
 	static void init(lua_State* L) {
 		ActionFunctions::init(L);
+		LookFunctions::init(L);
 		CreatureEventFunctions::init(L);
 		EventsSchedulerFunctions::init(L);
 		GlobalEventFunctions::init(L);

--- a/src/lua/functions/events/look_functions.cpp
+++ b/src/lua/functions/events/look_functions.cpp
@@ -1,0 +1,195 @@
+#include "pch.hpp"
+
+#include "lua/creature/looks.hpp"
+#include "lua/functions/events/look_functions.hpp"
+#include "game/game.hpp"
+#include "items/item.hpp"
+
+int LookFunctions::luaCreateLook(lua_State* L) {
+	// Look()
+	auto look = std::make_shared<Look>(getScriptEnv()->getScriptInterface());
+	pushUserdata<Look>(L, look);
+	setMetatable(L, -1, "Look");
+	return 1;
+}
+
+int LookFunctions::luaLookOnLook(lua_State* L) {
+	// look:onLook(callback)
+	const auto action = getUserdataShared<Look>(L, 1);
+	if (action) {
+		if (!action->loadCallback()) {
+			pushBoolean(L, false);
+			return 1;
+		}
+		action->setLoadedCallback(true);
+		pushBoolean(L, true);
+	} else {
+		reportErrorFunc(getErrorDesc(LUA_ERROR_ACTION_NOT_FOUND));
+		pushBoolean(L, false);
+	}
+	return 1;
+}
+
+int LookFunctions::luaLookRegister(lua_State* L) {
+	// look:register()
+	const auto action = getUserdataShared<Look>(L, 1);
+	if (action) {
+		if (!action->isLoadedCallback()) {
+			pushBoolean(L, false);
+			return 1;
+		}
+		pushBoolean(L, g_looks().registerLuaEvent(action));
+		pushBoolean(L, true);
+	} else {
+		reportErrorFunc(getErrorDesc(LUA_ERROR_ACTION_NOT_FOUND));
+		pushBoolean(L, false);
+	}
+	return 1;
+}
+
+int LookFunctions::luaLookItemId(lua_State* L) {
+	// look:id(ids)
+	const auto action = getUserdataShared<Look>(L, 1);
+	if (action) {
+		int parameters = lua_gettop(L) - 1; // - 1 because self is a parameter aswell, which we want to skip ofc
+		if (parameters > 1) {
+			for (int i = 0; i < parameters; ++i) {
+				action->setItemIdsVector(getNumber<uint16_t>(L, 2 + i));
+			}
+		} else {
+			action->setItemIdsVector(getNumber<uint16_t>(L, 2));
+		}
+		pushBoolean(L, true);
+	} else {
+		reportErrorFunc(getErrorDesc(LUA_ERROR_ACTION_NOT_FOUND));
+		pushBoolean(L, false);
+	}
+	return 1;
+}
+
+int LookFunctions::luaLookActionId(lua_State* L) {
+	// look:aid(aids)
+	const auto action = getUserdataShared<Look>(L, 1);
+	if (action) {
+		int parameters = lua_gettop(L) - 1; // - 1 because self is a parameter aswell, which we want to skip ofc
+		if (parameters > 1) {
+			for (int i = 0; i < parameters; ++i) {
+				action->setActionIdsVector(getNumber<uint16_t>(L, 2 + i));
+			}
+		} else {
+			action->setActionIdsVector(getNumber<uint16_t>(L, 2));
+		}
+		pushBoolean(L, true);
+	} else {
+		reportErrorFunc(getErrorDesc(LUA_ERROR_ACTION_NOT_FOUND));
+		pushBoolean(L, false);
+	}
+	return 1;
+}
+
+int LookFunctions::luaLookUniqueId(lua_State* L) {
+	// look:uid(uids)
+	const auto action = getUserdataShared<Look>(L, 1);
+	if (action) {
+		int parameters = lua_gettop(L) - 1; // - 1 because self is a parameter aswell, which we want to skip ofc
+		if (parameters > 1) {
+			for (int i = 0; i < parameters; ++i) {
+				action->setUniqueIdsVector(getNumber<uint16_t>(L, 2 + i));
+			}
+		} else {
+			action->setUniqueIdsVector(getNumber<uint16_t>(L, 2));
+		}
+		pushBoolean(L, true);
+	} else {
+		reportErrorFunc(getErrorDesc(LUA_ERROR_ACTION_NOT_FOUND));
+		pushBoolean(L, false);
+	}
+	return 1;
+}
+
+int LookFunctions::luaLookPosition(lua_State* L) {
+	/** @brief Create action position
+	 * @param positions = position or table of positions to set a action script
+	 * @param itemId or @param itemName = if item id or string name is set, the item is created on position (if not exists), this variable is nil by default
+	 * action:position(positions, itemId or name)
+	 */
+	const auto action = getUserdataShared<Look>(L, 1);
+	if (!action) {
+		reportErrorFunc(getErrorDesc(LUA_ERROR_ACTION_NOT_FOUND));
+		pushBoolean(L, false);
+		return 1;
+	}
+
+	Position position = getPosition(L, 2);
+	// The parameter "- 1" because self is a parameter aswell, which we want to skip L 1 (UserData)
+	// isNumber(L, 2) is for skip the itemId
+	if (int parameters = lua_gettop(L) - 1;
+	    parameters > 1 && isNumber(L, 2)) {
+		for (int i = 0; i < parameters; ++i) {
+			action->setPositionsVector(getPosition(L, 2 + i));
+		}
+	} else {
+		action->setPositionsVector(position);
+	}
+
+	uint16_t itemId;
+	bool createItem = false;
+	if (isNumber(L, 3)) {
+		itemId = getNumber<uint16_t>(L, 3);
+		createItem = true;
+	} else if (isString(L, 3)) {
+		itemId = Item::items.getItemIdByName(getString(L, 3));
+		if (itemId == 0) {
+			reportErrorFunc("Not found item with name: " + getString(L, 3));
+			pushBoolean(L, false);
+			return 1;
+		}
+
+		createItem = true;
+	}
+
+	if (createItem) {
+		if (!Item::items.hasItemType(itemId)) {
+			reportErrorFunc("Not found item with id: " + itemId);
+			pushBoolean(L, false);
+			return 1;
+		}
+
+		// If it is an item that can be removed, then it will be set as non-movable.
+		ItemType &itemType = Item::items.getItemType(itemId);
+		if (itemType.movable == true) {
+			itemType.movable = false;
+		}
+
+		g_game().setCreateLuaItems(position, itemId);
+	}
+
+	pushBoolean(L, true);
+	return 1;
+}
+
+int LookFunctions::luaLookBlockWalls(lua_State* L) {
+	// look:blockWalls(bool)
+	const auto action = getUserdataShared<Look>(L, 1);
+	if (action) {
+		action->setCheckLineOfSight(getBoolean(L, 2));
+		pushBoolean(L, true);
+	} else {
+		reportErrorFunc(getErrorDesc(LUA_ERROR_ACTION_NOT_FOUND));
+		pushBoolean(L, false);
+	}
+	return 1;
+}
+
+int LookFunctions::luaLookCheckFloor(lua_State* L) {
+	// look:checkFloor(bool)
+	const auto action = getUserdataShared<Look>(L, 1);
+	if (action) {
+		action->setCheckFloor(getBoolean(L, 2));
+		pushBoolean(L, true);
+	} else {
+		reportErrorFunc(getErrorDesc(LUA_ERROR_ACTION_NOT_FOUND));
+		pushBoolean(L, false);
+	}
+	return 1;
+}

--- a/src/lua/functions/events/look_functions.hpp
+++ b/src/lua/functions/events/look_functions.hpp
@@ -1,0 +1,39 @@
+/**
+ * Canary - A free and open-source MMORPG server emulator
+ * Copyright (©) 2019-2024 OpenTibiaBR <opentibiabr@outlook.com>
+ * Repository: https://github.com/opentibiabr/canary
+ * License: https://github.com/opentibiabr/canary/blob/main/LICENSE
+ * Contributors: https://github.com/opentibiabr/canary/graphs/contributors
+ * Website: https://docs.opentibiabr.com/
+ */
+
+#pragma once
+
+#include "lua/scripts/luascript.hpp"
+
+class LookFunctions final : LuaScriptInterface {
+public:
+	static void init(lua_State* L) {
+		registerSharedClass(L, "Look", "", LookFunctions::luaCreateLook);
+		registerMethod(L, "Look", "onLook", LookFunctions::luaLookOnLook);
+		registerMethod(L, "Look", "register", LookFunctions::luaLookRegister);
+		registerMethod(L, "Look", "id", LookFunctions::luaLookItemId);
+		registerMethod(L, "Look", "aid", LookFunctions::luaLookActionId);
+		registerMethod(L, "Look", "uid", LookFunctions::luaLookUniqueId);
+		registerMethod(L, "Look", "position", LookFunctions::luaLookPosition);
+		registerMethod(L, "Look", "blockWalls", LookFunctions::luaLookBlockWalls);
+		registerMethod(L, "Look", "checkFloor", LookFunctions::luaLookCheckFloor);
+		registerMethod(L, "Look", "position", LookFunctions::luaLookPosition);
+	}
+
+private:
+	static int luaCreateLook(lua_State* L);
+	static int luaLookOnLook(lua_State* L);
+	static int luaLookRegister(lua_State* L);
+	static int luaLookItemId(lua_State* L);
+	static int luaLookActionId(lua_State* L);
+	static int luaLookUniqueId(lua_State* L);
+	static int luaLookPosition(lua_State* L);
+	static int luaLookBlockWalls(lua_State* L);
+	static int luaLookCheckFloor(lua_State* L);
+};

--- a/vcproj/canary.vcxproj
+++ b/vcproj/canary.vcxproj
@@ -125,6 +125,7 @@
     <ClInclude Include="..\src\lua\creature\actions.hpp" />
     <ClInclude Include="..\src\lua\creature\creatureevent.hpp" />
     <ClInclude Include="..\src\lua\creature\events.hpp" />
+    <ClInclude Include="..\src\lua\creature\looks.hpp" />
     <ClInclude Include="..\src\lua\creature\movement.hpp" />
     <ClInclude Include="..\src\lua\creature\raids.hpp" />
     <ClInclude Include="..\src\lua\creature\talkaction.hpp" />
@@ -172,6 +173,7 @@
     <ClInclude Include="..\src\lua\functions\events\events_functions.hpp" />
     <ClInclude Include="..\src\lua\functions\events\events_scheduler_functions.hpp" />
     <ClInclude Include="..\src\lua\functions\events\global_event_functions.hpp" />
+    <ClInclude Include="..\src\lua\functions\events\look_functions.hpp" />
     <ClInclude Include="..\src\lua\functions\events\move_event_functions.hpp" />
     <ClInclude Include="..\src\lua\functions\events\talk_action_functions.hpp" />
     <ClInclude Include="..\src\lua\functions\items\container_functions.hpp" />
@@ -325,6 +327,7 @@
     <ClCompile Include="..\src\lua\creature\actions.cpp" />
     <ClCompile Include="..\src\lua\creature\creatureevent.cpp" />
     <ClCompile Include="..\src\lua\creature\events.cpp" />
+    <ClCompile Include="..\src\lua\creature\looks.cpp" />
     <ClCompile Include="..\src\lua\creature\movement.cpp" />
     <ClCompile Include="..\src\lua\creature\raids.cpp" />
     <ClCompile Include="..\src\lua\creature\talkaction.cpp" />
@@ -367,6 +370,7 @@
     <ClCompile Include="..\src\lua\functions\events\event_callback_functions.cpp" />
     <ClCompile Include="..\src\lua\functions\events\events_scheduler_functions.cpp" />
     <ClCompile Include="..\src\lua\functions\events\global_event_functions.cpp" />
+    <ClCompile Include="..\src\lua\functions\events\look_functions.cpp" />
     <ClCompile Include="..\src\lua\functions\events\move_event_functions.cpp" />
     <ClCompile Include="..\src\lua\functions\events\talk_action_functions.cpp" />
     <ClCompile Include="..\src\lua\functions\items\container_functions.cpp" />
@@ -604,4 +608,3 @@
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>
 </Project>
-


### PR DESCRIPTION
OnLook can be registered per uid/aid/id/pos.

example:

local item = Look()
function item.onLook(player, targetItem, usePosition, targetCreatureOrItem, targetPosition)
        logger.info("FastMoaLever onLook test")
	return true
end
item:aid(Storage.DesertQuestTwo.Puzzles.FastMoaLever)
item:register()
